### PR TITLE
fix: only reset the commitlint file if it is present

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -50,6 +50,7 @@ runs:
         # This /github/home is the internal Docker mount of $RUNNER_TEMP/_github_home
         NODE_PATH: /github/home/node_modules
     - name: Clear commitlint config changes
+      if: hashFiles(inputs.config-file) != ''
       shell: bash
       run: |
         git checkout "${{ inputs.config-file }}"


### PR DESCRIPTION

**Description**

This will only cause the commitlint file to be reset if the file is present in the repo.



**Changes**

* fix: only reset the commitlint file if it is present

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
