### PR TITLE
fix: action not working when running in Github Runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,8 @@ jobs:
           fetch-depth: 0
       - name: Setup python
         uses: actions/setup-python@v4
+        with:
+          python-version-file: ".python-version"
       - name: Install pre-commit
         run: |
           # Install pre-commit

--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 GitHub Action for running pre-commit hooks against the consumer repository. Conditionally installs tools needed for the Action to be able to perform its duties such as `npm`, `pre-commit`, etc.
 
-This will also check out the repository with `fetch-depth: 0` if it isn't already present in the workspace.
-
 ## Usage
 
 ```yaml
 jobs:
   lint:
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: open-turo/action-pre-commit@v1
 ```
 

--- a/action.yaml
+++ b/action.yaml
@@ -47,6 +47,8 @@ runs:
       # Only run this if we don't already have a pre-commit on the PATH
       if: env.PRE_COMMIT_BIN == null
       uses: actions/setup-python@v4
+      with:
+        python-version: 3.10.2
     - name: Conditionally install tools
       if: env.NEED_TO_SETUP_TOOLS
       uses: open-turo/action-setup-tools@v1


### PR DESCRIPTION
**Description**

This PR allows the action to work on Github runners. See it working in https://github.com/open-turo/eslint-config-typescript/pull/46

It also fixes docs that state that the action checks out the repo, when it doesn't actually.

The action stopped working when run on GHA runners. See an example failure here: https://github.com/open-turo/action-setup-tools/runs/7413611698?check_suite_focus=true

**Changes**

* fix: install python from python-version

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
