### PR TITLE
fix: for when turo-conventional-commit provided false

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -64,7 +64,7 @@ runs:
           "@open-turo/commitlint-config-conventional" \
           "@commitlint/cli"
     - name: Commitlint
-      if: hashFiles(inputs.config-file) != ''
+      if: hashFiles(inputs.config-file) != '' && inputs.turo-conventional-commit
       shell: bash
       run: |
         # Commitlint


### PR DESCRIPTION
This change appears needed as when providing `turo-conventional-commit: false`, conventional commits are still being enforced.