### PR TITLE
DSCI-3589: Fix python-version mismatch for action-pre-commit / action-python

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -54,6 +54,10 @@ runs:
         # Finding poetry
         # This will set an environment variable we can use to conditionally
         # install poetry.
+        # if poetry is installed we want to make sure it uses the right python
+        # version in case there are multiple python versions. This is
+        # particularly important for repositories that do not use the same
+        # python version as the default python version installed on the runners.
         echo "POETRY_BIN=$(command -v poetry)" >> $GITHUB_ENV
     - name: Find python
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -48,6 +48,13 @@ runs:
         # This will set an environment variable we can use to conditionally
         # install pre-commit if needed and toggle how the action runs.
         echo "PRE_COMMIT_BIN=$(command -v pre-commit)" >> $GITHUB_ENV
+    - name: Find poetry
+      shell: bash
+      run: |
+        # Finding poetry
+        # This will set an environment variable we can use to conditionally
+        # install poetry.
+        echo "POETRY_BIN=$(command -v poetry)" >> $GITHUB_ENV
     - name: Find python
       shell: bash
       run: |
@@ -55,6 +62,8 @@ runs:
         # This will set an environment variable we can use to conditionally
         # install python.
         echo "PYTHON_BIN=$(command -v python)" >> $GITHUB_ENV
+        echo "PYTHON_VERSION_SET=$(pyenv version-name)" >> $GITHUB_ENV
+        #add as debug the python versions and
     - name: Setup python
       # Only run this if we don't already have a pre-commit on the PATH
       if: env.PYTHON_BIN == null
@@ -165,11 +174,17 @@ runs:
       uses: pre-commit/action@v3.0.0
       with:
         extra_args: ${{ env.PRE_COMMIT_FILES }}
+    - name: Set poetry env to match python version
+      if: env.POETRY_BIN != null
+      shell: bash
+      run: |
+        poetry env use ${{ env.PYTHON_VERSION_SET }}
     - name: Pre-commit
       # Run pre-commit directly if we found it on the PATH
       if: env.PRE_COMMIT_BIN != null
       shell: bash
-      run: pre-commit run --show-diff-on-failure --color=always ${{ env.PRE_COMMIT_FILES }}
+      run: |
+        pre-commit run --show-diff-on-failure --color=always ${{ env.PRE_COMMIT_FILES }}
     - name: Clean up
       # Delete the python version file if we created it
       if: steps.create-python-version-file.outputs.file-created == 'true'


### PR DESCRIPTION
**Description**

open-turo/actions-python/lint uses open-turo/action-pre-commit. In the current setup action-pre-commit sets a python version (3.10.4) that is different than the one that gets used in the action.

We want to update action-pre-commit to be compatible with actions-python and properly set up python versions.

**Changes**
fix: get poetry to use the same python version as pre-commit
