### PR TITLE
Put poetry command behind a flag

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -54,17 +54,6 @@ runs:
         # This will set an environment variable we can use to conditionally
         # install pre-commit if needed and toggle how the action runs.
         echo "PRE_COMMIT_BIN=$(command -v pre-commit)" >> $GITHUB_ENV
-    - name: Find poetry
-      shell: bash
-      run: |
-        # Finding poetry
-        # This will set an environment variable we can use to conditionally
-        # install poetry.
-        # if poetry is installed we want to make sure it uses the right python
-        # version in case there are multiple python versions. This is
-        # particularly important for repositories that do not use the same
-        # python version as the default python version installed on the runners.
-        echo "POETRY_BIN=$(command -v poetry)" >> $GITHUB_ENV
     - name: Find python
       shell: bash
       run: |
@@ -184,11 +173,6 @@ runs:
       uses: pre-commit/action@v3.0.0
       with:
         extra_args: ${{ env.PRE_COMMIT_FILES }}
-    - name: Set poetry env to match python version
-      if: (env.POETRY_BIN != null) && (inputs.align-poetry-version == 'true')
-      shell: bash
-      run: |
-        poetry env use ${{ env.PYTHON_VERSION_SET }}
     - name: Pre-commit
       # Run pre-commit directly if we found it on the PATH
       if: env.PRE_COMMIT_BIN != null

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,12 @@ inputs:
     description: >-
       Set this to "true" to only run pre-commit against changed files, and not
       the entire repository
+  align-poetry-version:
+    required: false
+    description: >-
+      Set this to "true" to align the poetry python version to the python
+      version used by pre-commit
+    default: "false"
 
 runs:
   using: composite
@@ -179,7 +185,7 @@ runs:
       with:
         extra_args: ${{ env.PRE_COMMIT_FILES }}
     - name: Set poetry env to match python version
-      if: env.POETRY_BIN != null
+      if: (env.POETRY_BIN != null) && (inputs.align-poetry-version == 'true')
       shell: bash
       run: |
         poetry env use ${{ env.PYTHON_VERSION_SET }}


### PR DESCRIPTION
In the case where poetry is not installed in the current version and we do not really need it, we want to skip the poetry env use command to avoid it failing. In very specific cases such as `turo/orion` we do want to align the poetry version to the current env.