### PR TITLE
Conditionalize config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  # test action works running from the graph
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -41,6 +40,17 @@ jobs:
           pip install pre-commit
       - name: Pre-commit
         uses: ./
+
+  test-commitlint:
+    name: Test / Commitlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Commitlint
+        uses: ./commitlint
 
   # test-oss tries to run pre-commit against open source repositories not in
   # open-turo to make sure this is usuable outside the org.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: ./commitlint
 
   # test-oss tries to run pre-commit against open source repositories not in
-  # open-turo to make sure this is usuable outside the org.
+  # open-turo to make sure this is usable outside the org.
   # Repositories added to this list should have pre-commit hooks that don't
   # require external tooling to be installed.
   # Repositories added to this list must have passing pre-commit hooks.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,5 +73,4 @@ jobs:
         with:
           repository: ${{ matrix.repos }}
       - name: Pre-commit
-        # TODO: use a released version of this action
-        uses: open-turo/action-pre-commit@conditionalize-config
+        uses: open-turo/action-pre-commit@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: open-turo/actions-gha/lint@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # test action works running from the graph
   test:
@@ -39,3 +41,27 @@ jobs:
           pip install pre-commit
       - name: Pre-commit
         uses: ./
+
+  # test-oss tries to run pre-commit against open source repositories not in
+  # open-turo to make sure this is usuable outside the org.
+  # Repositories added to this list should have pre-commit hooks that don't
+  # require external tooling to be installed.
+  # Repositories added to this list must have passing pre-commit hooks.
+  test-oss:
+    name: Test / Open source
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repos:
+          - google/uv-metrics
+          - toml-lang/toml
+          - pre-commit/pre-commit
+          - actions/starter-workflows
+          - python/peps
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.repos }}
+      - name: Pre-commit
+        # TODO: use a released version of this action
+        uses: open-turo/action-pre-commit@conditionalize-config

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 node_modules/
 .DS_Store
+.vscode

--- a/action.yaml
+++ b/action.yaml
@@ -19,94 +19,53 @@ runs:
   using: composite
   steps:
     - name: Check for pre-commit-config.yaml
-      id: check-config
+      id: pre-commit-config
       shell: bash
       run: |
         # Check for pre-commit-config.yaml
         if [[ ! -f .pre-commit-config.yaml ]]; then
           echo "::warning::No .pre-commit-config.yaml found, skipping pre-commit"
-          echo "found-config=false" >> $GITHUB_OUTPUT
+          echo "exists=false" >> $GITHUB_OUTPUT
           exit 0
         fi
-    - name: Cancel workflow
-      uses: actions/github-script@v6
-      if: steps.check-config.outputs.found-config == 'false'
-      with:
-        result-encoding: string
-        retries: 3
-        script: |
-          github.rest.actions.cancelWorkflowRun({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            run_id: context.runId,
-          });
-
-          let count = 180;
-          const check = () => {
-            count -= 1;
-            github.rest.actions.getWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId,
-            }).then((run) => {
-              if (run.conclusion || run.status == "completed") {
-                return
-              }
-              console.log("Waiting for workflow to cancel")
-              console.log(run)
-
-              if (count > 0) {
-                setTimeout(check, 1000)
-              } else {
-                console.log("Workflow did not cancel in time")
-              }
-            })
-          }
-          setTimeout(check, 1)
-
-    - name: Set node.js version
-      if: hashFiles('.node-version') == ''
+    - name: Version files
       shell: bash
       run: |
-        # Get the existing node version, if the command exists
-        desired_version="$(node --version || true)"
-        # Chain defaults to get a good value
-        desired_version="${desired_version:-${NODENV_VERSION:-${NODE_VERSION:-16.19.1}}}"
-        # Strip the leading "v" in e.g. "v16.0.0", since .node-version will not work with it
-        desired_version="${desired_version#v}"
-        # Set the version so action-setup-tools can use it later
-        echo "$desired_version" > .node-version
-    - name: Set Python version
-      if: hashFiles('.python-version') == ''
-      id: create-python-version-file
-      shell: bash
-      run: |
-        # Use the .python-version from the action repo as the default version
+        # Try to use local repo .node-version
+        NODE_VERSION="${NODE_VERSION:-$(cat ".node-version")}"
+        # Try to use existing version
+        NODE_VERSION="${NODE_VERSION:-$(node --version || true)}"
+        # Try to use action default version
+        NODE_VERSION="${NODE_VERSION:-$(cat "$GITHUB_ACTION_PATH/.node-version")}"
+        # Write back the file if it doesn't exist
+        [[ -f .node-version ]] || { echo "${NODE_VERSION#v}" > .node-version; echo "CLEAN_NODE_VERSION=true" >> "$GITHUB_ENV"; }
+        echo "NODE_VERSION=${NODE_VERSION}" >> "$GITHUB_ENV"
+
+        # Try to use local repo .python-version
+        PYTHON_VERSION="${PYTHON_VERSION:-$(cat ".python-version")}"
+        # Try to use existing version
+        PYTHON_VERSION="${PYTHON_VERSION:-$(python --version || true)}"
+        # Try to use action default version
         PYTHON_VERSION="${PYTHON_VERSION:-$(cat "$GITHUB_ACTION_PATH/.python-version")}"
-        echo "$PYTHON_VERSION" > .python-version
+        # Write back the file if it doesn't exist
+        [[ -f .python-version ]] || { echo "${PYTHON_VERSION#v}" > .python-version; echo "CLEAN_PYTHON_VERSION=true" >> "$GITHUB_ENV"; }
         echo "PYTHON_VERSION=${PYTHON_VERSION}" >> "$GITHUB_ENV"
-        # Store as output that the file was created so we can clean up afterwards
-        echo "file-created=true" >> "$GITHUB_OUTPUT"
-    - name: Find pre-commit
-      shell: bash
-      run: |
+
         # Finding pre-commit
         # This will set an environment variable we can use to conditionally
         # install pre-commit if needed and toggle how the action runs.
         echo "PRE_COMMIT_BIN=$(command -v pre-commit)" >> $GITHUB_ENV
-    - name: Find python
-      shell: bash
-      run: |
+
         # Finding python
         # This will set an environment variable we can use to conditionally
         # install python.
         echo "PYTHON_BIN=$(command -v python)" >> $GITHUB_ENV
     - name: Setup python
       # Only run this if we don't already have a pre-commit on the PATH
-      if: env.PYTHON_BIN == null
+      if: env.PYTHON_BIN == null && env.PRE_COMMIT_BIN == null && steps.pre-commit-config.outputs.exists != 'false'
       uses: actions/setup-python@v4
-      # with:
-      #   python-version: 3.10.2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
     - name: Install tools
       # This will skip the (slow) pyenv install if we triggered the above
       uses: open-turo/action-setup-tools@v1
@@ -195,42 +154,40 @@ runs:
           --color \
           --from "$FROM" \
           --to HEAD
+    - name: Get changed files
+      uses: tj-actions/changed-files@v40
+      if: inputs.only-changed == 'true'
+      id: changed-files
+    - name: Select files to run pre-commit against
+      shell: bash
+      run: |
+        echo "PRE_COMMIT_ARGS=--all-files" >> "$GITHUB_ENV"
+        [[ "${{ steps.changed-files.outputs.any_changed }}" == "true" ]] || exit 0
+        if [[ "${{ inputs.only-changed }}" == "true" ]]; then
+          PRE_COMMIT_ARGS="--files ${{ steps.changed-files.outputs.files}}"
+          echo "PRE_COMMIT_ARGS=$PRE_COMMIT_ARGS" >> "$GITHUB_ENV"
+        fi
+    - name: Pre-commit (action)
+      # Same as above, this will install and run pre-commit for us
+      if: env.PRE_COMMIT_BIN == null && steps.pre-commit-config.outputs.exists != 'false'
+      uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: ${{ env.PRE_COMMIT_ARGS }}
+    - name: Pre-commit (from PATH)
+      # Run pre-commit directly if we found it on the PATH
+      if: env.PRE_COMMIT_BIN != null && steps.pre-commit-config.outputs.exists != 'false'
+      shell: bash
+      run: pre-commit run --show-diff-on-failure --color=always ${{ env.PRE_COMMIT_ARGS }}
+    - name: Clean up version files
+      if: always()
+      shell: bash
+      run: |
+        # Clean up version files if we wrote them
+        [[ "${{ env.CLEAN_PYTHON_VERSION }}" == "" ]] || rm .python-version
+        [[ "${{ env.CLEAN_NODE_VERSION }}" == "" ]] || rm .node-version
     - name: Restore commitlint config
       if: always() && hashFiles(inputs.config-file) != '' && inputs.turo-conventional-commit == 'true'
       shell: bash
-      run: git checkout -- "${{ inputs.config-file }}" || true
-    # Collect file changes
-    - name: Find changed files
-      if: inputs.only-changed == 'true'
-      uses: trilom/file-changes-action@v1.2.4
-      id: file_changes
-      with:
-        output: " "
-    # Export changed file names for use in pre-commit action
-    - name: Limit pre-commit to changed files
-      if: inputs.only-changed == 'true'
-      shell: bash
       run: |
-        PRE_COMMIT_FILES="--files ${{ steps.file_changes.outputs.files}}"
-        echo PRE_COMMIT_FILES="$PRE_COMMIT_FILES" >> $GITHUB_ENV
-    # If we aren't only looking at changed files, then export the --all-files arg
-    - name: Run pre-commit against all files
-      if: inputs.only-changed != 'true'
-      shell: bash
-      run: echo PRE_COMMIT_FILES="--all-files" >> $GITHUB_ENV
-    - name: Pre-commit
-      # Same as above, this will install and run pre-commit for us
-      if: env.PRE_COMMIT_BIN == null
-      uses: pre-commit/action@v3.0.0
-      with:
-        extra_args: ${{ env.PRE_COMMIT_FILES }}
-    - name: Pre-commit
-      # Run pre-commit directly if we found it on the PATH
-      if: env.PRE_COMMIT_BIN != null
-      shell: bash
-      run: pre-commit run --show-diff-on-failure --color=always ${{ env.PRE_COMMIT_FILES }}
-    - name: Clean up
-      # Delete the python version file if we created it
-      if: steps.create-python-version-file.outputs.file-created == 'true'
-      shell: bash
-      run: rm .python-version
+        # Restore the commitlint config file if we wrote it
+        git checkout -- "${{ inputs.config-file }}" || true

--- a/action.yaml
+++ b/action.yaml
@@ -87,9 +87,9 @@ runs:
         # Write default commitlint config in the workspace.
         echo "extends: [\"@open-turo/commitlint-config-conventional\"]" \
           > "${{ inputs.config-file }}"
-        # XXX(shakefu): We have to list @commitlint/cli here otherwise `npm
-        # install` will try to remove it from the above step. There is no way to
-        # prevent this behavior that I'm aware of.
+        # We have to list @commitlint/cli here otherwise `npm install` will try
+        # to remove it from the above step. There is no way to prevent this
+        # behavior that I'm aware of.
         npm install --no-save --no-package-lock --no-audit --no-fund \
           --prefix "$RUNNER_TEMP" \
           "@open-turo/commitlint-config-conventional" \

--- a/action.yaml
+++ b/action.yaml
@@ -18,6 +18,52 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Check for pre-commit-config.yaml
+      id: check-config
+      shell: bash
+      run: |
+        # Check for pre-commit-config.yaml
+        if [[ ! -f .pre-commit-config.yaml ]]; then
+          echo "::warning::No .pre-commit-config.yaml found, skipping pre-commit"
+          echo "found-config=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+    - name: Cancel workflow
+      uses: actions/github-script@v6
+      if: steps.check-config.outputs.found-config == 'false'
+      with:
+        result-encoding: string
+        retries: 3
+        script: |
+          github.rest.actions.cancelWorkflowRun({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId,
+          });
+
+          let count = 180;
+          const check = () => {
+            count -= 1;
+            github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            }).then((run) => {
+              if (run.conclusion || run.status == "completed") {
+                return
+              }
+              console.log("Waiting for workflow to cancel")
+              console.log(run)
+
+              if (count > 0) {
+                setTimeout(check, 1000)
+              } else {
+                console.log("Workflow did not cancel in time")
+              }
+            })
+          }
+          setTimeout(check, 1)
+
     - name: Set node.js version
       if: hashFiles('.node-version') == ''
       shell: bash
@@ -98,7 +144,14 @@ runs:
             echo "::notice::Parsing base ref '$FROM'"
             # If we do have the base ref, it can be a branch name, so we want to
             # parse it. This will be a pass through for a SHA
-            FROM="$(git show-ref --hash "$FROM" | tail -n1)"
+            # via the event context, and we should try to find the default
+            # branch instead (see below)
+            if ! git show-ref --hash "$FROM" &>/dev/null; then
+              # No such ref, so we try the next step
+              FROM=""
+            else
+              FROM="$(git show-ref --hash "$FROM" | tail -n1)"
+            fi
           fi
         fi
         # If we don't have a base ref, we try to find the history to the default
@@ -135,6 +188,7 @@ runs:
         if [[ -n "$CONFIG_FILE" ]]; then
           CONFIG_FILE="--config $CONFIG_FILE"
         fi
+        echo "::notice::Running commitlint"
         commitlint \
           $CONFIG_FILE \
           --verbose \

--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,8 @@ runs:
     - name: Version files
       shell: bash
       run: |
+        # Find Node and Python versions
+
         # Try to use local repo .node-version
         NODE_VERSION="${NODE_VERSION:-$(cat ".node-version" || true)}"
         # Try to use existing version
@@ -80,91 +82,6 @@ runs:
         restore-config: "false"
         config-file: ${{ inputs.config-file }}
         turo-conventional-commit: ${{ inputs.turo-conventional-commit }}
-    # - name: Install @commitlint/cli
-    #   shell: bash
-    #   run: |
-    #     npm install --no-save --no-package-lock --no-audit --no-fund \
-    #       --prefix "$RUNNER_TEMP" "@commitlint/cli"
-    #     echo "$RUNNER_TEMP/node_modules/.bin" >> $GITHUB_PATH
-    #     echo "NODE_PATH=$RUNNER_TEMP/node_modules" >> $GITHUB_ENV
-    # - name: Use default conventional commit config
-    #   if: inputs.turo-conventional-commit == 'true'
-    #   shell: bash
-    #   run: |
-    #     # Write default commitlint config in the workspace.
-    #     echo "extends: [\"@open-turo/commitlint-config-conventional\"]" \
-    #       > "${{ inputs.config-file }}"
-    #     # We have to list @commitlint/cli here otherwise `npm install` will try
-    #     # to remove it from the above step. There is no way to prevent this
-    #     # behavior that I'm aware of.
-    #     npm install --no-save --no-package-lock --no-audit --no-fund \
-    #       --prefix "$RUNNER_TEMP" \
-    #       "@open-turo/commitlint-config-conventional" \
-    #       "@commitlint/cli"
-    # - name: Commitlint
-    #   if: hashFiles(inputs.config-file) != ''
-    #   shell: bash
-    #   run: |
-    #     # Commitlint
-    #     # Look for the base ref to compare against the current head in the
-    #     # pull_request event metadata.
-    #     if [[ -z "$FROM" ]]; then
-    #       FROM="${{ github.event.pull_request.base.ref }}"
-    #       if [[ -n "$FROM" ]]; then
-    #         echo "::notice::Parsing base ref '$FROM'"
-    #         # If we do have the base ref, it can be a branch name, so we want to
-    #         # parse it. This will be a pass through for a SHA
-    #         # via the event context, and we should try to find the default
-    #         # branch instead (see below)
-    #         if ! git show-ref --hash "$FROM" &>/dev/null; then
-    #           # No such ref, so we try the next step
-    #           FROM=""
-    #         else
-    #           FROM="$(git show-ref --hash "$FROM" | tail -n1)"
-    #         fi
-    #       fi
-    #     fi
-    #     # If we don't have a base ref, we try to find the history to the default
-    #     # branch, e.g. main, which should be a sane check.
-    #     if [[ -z "$FROM" ]]; then
-    #       # This finds the default branch name from the remote information, e.g. "main", and then parses it to a SHA
-    #       FROM="$(git show-ref --hash "$(git remote show $(git remote -v | grep push | awk '{print $2}') | grep 'HEAD branch' | awk '{print $3}')" | tail -n1)"
-    #       echo "::notice::Could not find base ref, trying to use default branch"
-    #       if ! git merge-base --is-ancestor "$FROM" HEAD; then
-    #         echo "::warning::Default branch is not an ancestor of HEAD"
-    #         FROM=""
-    #       fi
-    #     fi
-    #     # If the pull_request event metadata doesn't exist, try to grab the
-    #     # "before" commit from the push event metadata. This will usually only
-    #     # give us a single commit to check, but it'll be the latest one.
-    #     if [[ -z "$FROM" ]]; then
-    #       # This is a SHA so no parsing needed
-    #       FROM="${{ github.event.before }}"
-    #       echo "::warning::Could not find ancestor ref, falling back"
-    #       if ! git merge-base --is-ancestor "$FROM" HEAD; then
-    #         echo "::warning::Before commit $FROM is not an ancestor of HEAD"
-    #       else
-    #         echo "::notice::Checking commits since $FROM (usually the latest commit)."
-    #       fi
-    #     fi
-    #     # Default to looking at the last 20 commits otherwise.
-    #     if [[ -z "$FROM" ]]; then
-    #       FROM="HEAD~20"
-    #       echo "::warning::Could not find commit range for commitlint"
-    #       echo "::notice::Checking 20 most recent commit messages."
-    #     fi
-    #     CONFIG_FILE="${{ inputs.config-file }}"
-    #     if [[ -n "$CONFIG_FILE" ]]; then
-    #       CONFIG_FILE="--config $CONFIG_FILE"
-    #     fi
-    #     echo "::notice::Running commitlint"
-    #     commitlint \
-    #       $CONFIG_FILE \
-    #       --verbose \
-    #       --color \
-    #       --from "$FROM" \
-    #       --to HEAD
     - name: Get changed files
       uses: tj-actions/changed-files@v40
       if: inputs.only-changed == 'true'

--- a/action.yaml
+++ b/action.yaml
@@ -32,7 +32,7 @@ runs:
       shell: bash
       run: |
         # Try to use local repo .node-version
-        NODE_VERSION="${NODE_VERSION:-$(cat ".node-version")}"
+        NODE_VERSION="${NODE_VERSION:-$(cat ".node-version" || true)}"
         # Try to use existing version
         NODE_VERSION="${NODE_VERSION:-$(node --version || true)}"
         # Try to use action default version
@@ -42,11 +42,13 @@ runs:
         echo "NODE_VERSION=${NODE_VERSION}" >> "$GITHUB_ENV"
 
         # Try to use local repo .python-version
-        PYTHON_VERSION="${PYTHON_VERSION:-$(cat ".python-version")}"
+        PYTHON_VERSION="${PYTHON_VERSION:-$(cat ".python-version" || true)}"
         # Try to use existing version
         PYTHON_VERSION="${PYTHON_VERSION:-$(python --version || true)}"
         # Try to use action default version
         PYTHON_VERSION="${PYTHON_VERSION:-$(cat "$GITHUB_ACTION_PATH/.python-version")}"
+        # Strip leading "Python " if it exists
+        PYTHON_VERSION="${PYTHON_VERSION//Python /}"
         # Write back the file if it doesn't exist
         [[ -f .python-version ]] || { echo "${PYTHON_VERSION#v}" > .python-version; echo "CLEAN_PYTHON_VERSION=true" >> "$GITHUB_ENV"; }
         echo "PYTHON_VERSION=${PYTHON_VERSION}" >> "$GITHUB_ENV"
@@ -54,12 +56,14 @@ runs:
         # Finding pre-commit
         # This will set an environment variable we can use to conditionally
         # install pre-commit if needed and toggle how the action runs.
-        echo "PRE_COMMIT_BIN=$(command -v pre-commit)" >> $GITHUB_ENV
+        PRE_COMMIT_BIN=$(command -v pre-commit || true)
+        echo "PRE_COMMIT_BIN=$PRE_COMMIT_BIN" >> $GITHUB_ENV
 
         # Finding python
         # This will set an environment variable we can use to conditionally
         # install python.
-        echo "PYTHON_BIN=$(command -v python)" >> $GITHUB_ENV
+        PYTHON_BIN=$(command -v python || true)
+        echo "PYTHON_BIN=$PYTHON_BIN" >> $GITHUB_ENV
     - name: Setup python
       # Only run this if we don't already have a pre-commit on the PATH
       if: env.PYTHON_BIN == null && env.PRE_COMMIT_BIN == null && steps.pre-commit-config.outputs.exists != 'false'
@@ -190,4 +194,4 @@ runs:
       shell: bash
       run: |
         # Restore the commitlint config file if we wrote it
-        git checkout -- "${{ inputs.config-file }}" || true
+        git checkout -- "${{ inputs.config-file }}" &>/dev/null || true

--- a/action.yaml
+++ b/action.yaml
@@ -73,91 +73,98 @@ runs:
     - name: Install tools
       # This will skip the (slow) pyenv install if we triggered the above
       uses: open-turo/action-setup-tools@v1
-    - name: Install @commitlint/cli
-      shell: bash
-      run: |
-        npm install --no-save --no-package-lock --no-audit --no-fund \
-          --prefix "$RUNNER_TEMP" "@commitlint/cli"
-        echo "$RUNNER_TEMP/node_modules/.bin" >> $GITHUB_PATH
-        echo "NODE_PATH=$RUNNER_TEMP/node_modules" >> $GITHUB_ENV
-    - name: Use default conventional commit config
-      if: inputs.turo-conventional-commit == 'true'
-      shell: bash
-      run: |
-        # Write default commitlint config in the workspace.
-        echo "extends: [\"@open-turo/commitlint-config-conventional\"]" \
-          > "${{ inputs.config-file }}"
-        # We have to list @commitlint/cli here otherwise `npm install` will try
-        # to remove it from the above step. There is no way to prevent this
-        # behavior that I'm aware of.
-        npm install --no-save --no-package-lock --no-audit --no-fund \
-          --prefix "$RUNNER_TEMP" \
-          "@open-turo/commitlint-config-conventional" \
-          "@commitlint/cli"
     - name: Commitlint
-      if: hashFiles(inputs.config-file) != ''
-      shell: bash
-      run: |
-        # Commitlint
-        # Look for the base ref to compare against the current head in the
-        # pull_request event metadata.
-        if [[ -z "$FROM" ]]; then
-          FROM="${{ github.event.pull_request.base.ref }}"
-          if [[ -n "$FROM" ]]; then
-            echo "::notice::Parsing base ref '$FROM'"
-            # If we do have the base ref, it can be a branch name, so we want to
-            # parse it. This will be a pass through for a SHA
-            # via the event context, and we should try to find the default
-            # branch instead (see below)
-            if ! git show-ref --hash "$FROM" &>/dev/null; then
-              # No such ref, so we try the next step
-              FROM=""
-            else
-              FROM="$(git show-ref --hash "$FROM" | tail -n1)"
-            fi
-          fi
-        fi
-        # If we don't have a base ref, we try to find the history to the default
-        # branch, e.g. main, which should be a sane check.
-        if [[ -z "$FROM" ]]; then
-          # This finds the default branch name from the remote information, e.g. "main", and then parses it to a SHA
-          FROM="$(git show-ref --hash "$(git remote show $(git remote -v | grep push | awk '{print $2}') | grep 'HEAD branch' | awk '{print $3}')" | tail -n1)"
-          echo "::notice::Could not find base ref, trying to use default branch"
-          if ! git merge-base --is-ancestor "$FROM" HEAD; then
-            echo "::warning::Default branch is not an ancestor of HEAD"
-            FROM=""
-          fi
-        fi
-        # If the pull_request event metadata doesn't exist, try to grab the
-        # "before" commit from the push event metadata. This will usually only
-        # give us a single commit to check, but it'll be the latest one.
-        if [[ -z "$FROM" ]]; then
-          # This is a SHA so no parsing needed
-          FROM="${{ github.event.before }}"
-          echo "::warning::Could not find ancestor ref, falling back"
-          if ! git merge-base --is-ancestor "$FROM" HEAD; then
-            echo "::warning::Before commit $FROM is not an ancestor of HEAD"
-          else
-            echo "::notice::Checking commits since $FROM (usually the latest commit)."
-          fi
-        fi
-        # Default to looking at the last 20 commits otherwise.
-        if [[ -z "$FROM" ]]; then
-          FROM="HEAD~20"
-          echo "::warning::Could not find commit range for commitlint"
-          echo "::notice::Checking 20 most recent commit messages."
-        fi
-        CONFIG_FILE="${{ inputs.config-file }}"
-        if [[ -n "$CONFIG_FILE" ]]; then
-          CONFIG_FILE="--config $CONFIG_FILE"
-        fi
-        echo "::notice::Running commitlint"
-        commitlint \
-          $CONFIG_FILE \
-          --verbose \
-          --color \
-          --from "$FROM" \
-          --to HEAD
+      # TODO: use a released version of this action
+      uses: open-turo/action-pre-commit/commitlint@conditionalize-config
+      with:
+        restore-config: "false"
+        config-file: ${{ inputs.config-file }}
+        turo-conventional-commit: ${{ inputs.turo-conventional-commit }}
+    # - name: Install @commitlint/cli
+    #   shell: bash
+    #   run: |
+    #     npm install --no-save --no-package-lock --no-audit --no-fund \
+    #       --prefix "$RUNNER_TEMP" "@commitlint/cli"
+    #     echo "$RUNNER_TEMP/node_modules/.bin" >> $GITHUB_PATH
+    #     echo "NODE_PATH=$RUNNER_TEMP/node_modules" >> $GITHUB_ENV
+    # - name: Use default conventional commit config
+    #   if: inputs.turo-conventional-commit == 'true'
+    #   shell: bash
+    #   run: |
+    #     # Write default commitlint config in the workspace.
+    #     echo "extends: [\"@open-turo/commitlint-config-conventional\"]" \
+    #       > "${{ inputs.config-file }}"
+    #     # We have to list @commitlint/cli here otherwise `npm install` will try
+    #     # to remove it from the above step. There is no way to prevent this
+    #     # behavior that I'm aware of.
+    #     npm install --no-save --no-package-lock --no-audit --no-fund \
+    #       --prefix "$RUNNER_TEMP" \
+    #       "@open-turo/commitlint-config-conventional" \
+    #       "@commitlint/cli"
+    # - name: Commitlint
+    #   if: hashFiles(inputs.config-file) != ''
+    #   shell: bash
+    #   run: |
+    #     # Commitlint
+    #     # Look for the base ref to compare against the current head in the
+    #     # pull_request event metadata.
+    #     if [[ -z "$FROM" ]]; then
+    #       FROM="${{ github.event.pull_request.base.ref }}"
+    #       if [[ -n "$FROM" ]]; then
+    #         echo "::notice::Parsing base ref '$FROM'"
+    #         # If we do have the base ref, it can be a branch name, so we want to
+    #         # parse it. This will be a pass through for a SHA
+    #         # via the event context, and we should try to find the default
+    #         # branch instead (see below)
+    #         if ! git show-ref --hash "$FROM" &>/dev/null; then
+    #           # No such ref, so we try the next step
+    #           FROM=""
+    #         else
+    #           FROM="$(git show-ref --hash "$FROM" | tail -n1)"
+    #         fi
+    #       fi
+    #     fi
+    #     # If we don't have a base ref, we try to find the history to the default
+    #     # branch, e.g. main, which should be a sane check.
+    #     if [[ -z "$FROM" ]]; then
+    #       # This finds the default branch name from the remote information, e.g. "main", and then parses it to a SHA
+    #       FROM="$(git show-ref --hash "$(git remote show $(git remote -v | grep push | awk '{print $2}') | grep 'HEAD branch' | awk '{print $3}')" | tail -n1)"
+    #       echo "::notice::Could not find base ref, trying to use default branch"
+    #       if ! git merge-base --is-ancestor "$FROM" HEAD; then
+    #         echo "::warning::Default branch is not an ancestor of HEAD"
+    #         FROM=""
+    #       fi
+    #     fi
+    #     # If the pull_request event metadata doesn't exist, try to grab the
+    #     # "before" commit from the push event metadata. This will usually only
+    #     # give us a single commit to check, but it'll be the latest one.
+    #     if [[ -z "$FROM" ]]; then
+    #       # This is a SHA so no parsing needed
+    #       FROM="${{ github.event.before }}"
+    #       echo "::warning::Could not find ancestor ref, falling back"
+    #       if ! git merge-base --is-ancestor "$FROM" HEAD; then
+    #         echo "::warning::Before commit $FROM is not an ancestor of HEAD"
+    #       else
+    #         echo "::notice::Checking commits since $FROM (usually the latest commit)."
+    #       fi
+    #     fi
+    #     # Default to looking at the last 20 commits otherwise.
+    #     if [[ -z "$FROM" ]]; then
+    #       FROM="HEAD~20"
+    #       echo "::warning::Could not find commit range for commitlint"
+    #       echo "::notice::Checking 20 most recent commit messages."
+    #     fi
+    #     CONFIG_FILE="${{ inputs.config-file }}"
+    #     if [[ -n "$CONFIG_FILE" ]]; then
+    #       CONFIG_FILE="--config $CONFIG_FILE"
+    #     fi
+    #     echo "::notice::Running commitlint"
+    #     commitlint \
+    #       $CONFIG_FILE \
+    #       --verbose \
+    #       --color \
+    #       --from "$FROM" \
+    #       --to HEAD
     - name: Get changed files
       uses: tj-actions/changed-files@v40
       if: inputs.only-changed == 'true'

--- a/action.yaml
+++ b/action.yaml
@@ -76,8 +76,8 @@ runs:
       # This will skip the (slow) pyenv install if we triggered the above
       uses: open-turo/action-setup-tools@v1
     - name: Commitlint
-      # TODO: use a released version of this action
-      uses: open-turo/action-pre-commit/commitlint@conditionalize-config
+      # This version needs to be sync'd with the repo HEAD if a major version is cut
+      uses: open-turo/action-pre-commit/commitlint@v1
       with:
         restore-config: "false"
         config-file: ${{ inputs.config-file }}

--- a/action.yaml
+++ b/action.yaml
@@ -131,7 +131,12 @@ runs:
           echo "::warning::Could not find commit range for commitlint"
           echo "::notice::Checking 20 most recent commit messages."
         fi
-        commitlint --config "${{ inputs.config-file }}" \
+        CONFIG_FILE="${{ inputs.config-file }}"
+        if [[ -n "$CONFIG_FILE" ]]; then
+          CONFIG_FILE="--config $CONFIG_FILE"
+        fi
+        commitlint \
+          $CONFIG_FILE \
           --verbose \
           --color \
           --from "$FROM" \

--- a/commitlint/action.yaml
+++ b/commitlint/action.yaml
@@ -47,7 +47,7 @@ runs:
         if [[ -z "$FROM" ]]; then
           FROM="${{ github.event.pull_request.base.ref }}"
           if [[ -n "$FROM" ]]; then
-            echo "::notice::Parsing base ref '$FROM'"
+            echo "::debug::Parsing base ref '$FROM'"
             # If we do have the base ref, it can be a branch name, so we want to
             # parse it. This will be a pass through for a SHA
             # via the event context, and we should try to find the default
@@ -65,7 +65,7 @@ runs:
         if [[ -z "$FROM" ]]; then
           # This finds the default branch name from the remote information, e.g. "main", and then parses it to a SHA
           FROM="$(git show-ref --hash "$(git remote show $(git remote -v | grep push | awk '{print $2}') | grep 'HEAD branch' | awk '{print $3}')" | tail -n1)"
-          echo "::notice::Could not find base ref, trying to use default branch"
+          echo "::debug::Could not find base ref, trying to use default branch"
           if ! git merge-base --is-ancestor "$FROM" HEAD; then
             echo "::warning::Default branch is not an ancestor of HEAD"
             FROM=""
@@ -81,20 +81,20 @@ runs:
           if ! git merge-base --is-ancestor "$FROM" HEAD; then
             echo "::warning::Before commit $FROM is not an ancestor of HEAD"
           else
-            echo "::notice::Checking commits since $FROM (usually the latest commit)."
+            echo "::debug::Checking commits since $FROM (usually the latest commit)."
           fi
         fi
         # Default to looking at the last 20 commits otherwise.
         if [[ -z "$FROM" ]]; then
           FROM="HEAD~20"
           echo "::warning::Could not find commit range for commitlint"
-          echo "::notice::Checking 20 most recent commit messages."
+          echo "::debug::Checking 20 most recent commit messages."
         fi
         CONFIG_FILE="${{ inputs.config-file }}"
         if [[ -n "$CONFIG_FILE" ]]; then
           CONFIG_FILE="--config $CONFIG_FILE"
         fi
-        echo "::notice::Running commitlint"
+        echo "::debug::Running commitlint"
         commitlint \
           $CONFIG_FILE \
           --verbose \

--- a/commitlint/action.yaml
+++ b/commitlint/action.yaml
@@ -27,9 +27,9 @@ runs:
         # Write default commitlint config in the workspace.
         echo "extends: [\"@open-turo/commitlint-config-conventional\"]" \
           > "${{ inputs.config-file }}"
-        # XXX(shakefu): We have to list @commitlint/cli here otherwise `npm
-        # install` will try to remove it from the above step. There is no way to
-        # prevent this behavior that I'm aware of.
+        # We have to list @commitlint/cli here otherwise `npm install` will try
+        # to remove it from the above step. There is no way to prevent this
+        # behavior that I'm aware of.
         npm install --no-save --no-package-lock --no-audit --no-fund \
           --prefix "$RUNNER_TEMP" \
           "@open-turo/commitlint-config-conventional" \

--- a/commitlint/action.yaml
+++ b/commitlint/action.yaml
@@ -9,6 +9,9 @@ inputs:
     required: true
     description: Set this to "false" to customize conventional commit config
     default: "true"
+  restore-config:
+    description: Set to "false" to skip the configuration restore step
+    default: "true"
 
 runs:
   using: composite
@@ -99,7 +102,7 @@ runs:
           --from "$FROM" \
           --to HEAD
     - name: Restore commitlint config
-      if: always() && hashFiles(inputs.config-file) != '' && inputs.turo-conventional-commit == 'true'
+      if: always() && hashFiles(inputs.config-file) != '' && inputs.turo-conventional-commit == 'true' && inputs.restore-config == 'true'
       shell: bash
       run: |
         # Restore the commitlint config file if we wrote it

--- a/commitlint/action.yaml
+++ b/commitlint/action.yaml
@@ -47,7 +47,14 @@ runs:
             echo "::notice::Parsing base ref '$FROM'"
             # If we do have the base ref, it can be a branch name, so we want to
             # parse it. This will be a pass through for a SHA
-            FROM="$(git show-ref --hash "$FROM" | tail -n1)"
+            # via the event context, and we should try to find the default
+            # branch instead (see below)
+            if ! git show-ref --hash "$FROM" &>/dev/null; then
+              # No such ref, so we try the next step
+              FROM=""
+            else
+              FROM="$(git show-ref --hash "$FROM" | tail -n1)"
+            fi
           fi
         fi
         # If we don't have a base ref, we try to find the history to the default
@@ -80,12 +87,20 @@ runs:
           echo "::warning::Could not find commit range for commitlint"
           echo "::notice::Checking 20 most recent commit messages."
         fi
-        commitlint --config "${{ inputs.config-file }}" \
+        CONFIG_FILE="${{ inputs.config-file }}"
+        if [[ -n "$CONFIG_FILE" ]]; then
+          CONFIG_FILE="--config $CONFIG_FILE"
+        fi
+        echo "::notice::Running commitlint"
+        commitlint \
+          $CONFIG_FILE \
           --verbose \
           --color \
           --from "$FROM" \
           --to HEAD
     - name: Restore commitlint config
-      if: always() && hashFiles(inputs.config-file) != '' && inputs.turo-conventional-commit
+      if: always() && hashFiles(inputs.config-file) != '' && inputs.turo-conventional-commit == 'true'
       shell: bash
-      run: git checkout -- "${{ inputs.config-file }}" || true
+      run: |
+        # Restore the commitlint config file if we wrote it
+        git checkout -- "${{ inputs.config-file }}" &>/dev/null || true


### PR DESCRIPTION
- Fixes behavior so that if .pre-commit-config.yaml is missing, it won't fail the check
- Conditionalizes the config param to work if there is no commitlint config
- Handle edge case where executing repo's context.base_ref is different from workspace repo's (e.g. if we're on main, but check is running against a repo with master)
- Add CI tests running against compliant OSS repositories
- Refactor to use commitlint subaction instead of reproducing code