### PR TITLE
feat: add support to cache pre-commit in s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,16 @@ jobs:
 | config-file | The config file to present to commitlint-github-action | `true` | .commitlintrc.yaml |
 | turo-conventional-commit | Set this to "false" to customize conventional commit configuration | `true` | true |
 | only-changed | Set this to "true" to only run pre-commit against changed files, and not the entire repository | `false` |  |
+| s3-bucket-name | S3 bucket name to cache node_modules to speed up dependency installation. | `false` |  |
+| s3-bucket-region | S3 bucket region to cache node_modules to speed up dependency installation. | `false` |  |
 <!-- action-docs-inputs -->
 
 <!-- action-docs-outputs -->
+## Outputs
 
+| parameter | description |
+| --- | --- |
+| cache-hit | Whether the cache was hit when installing dependencies |
 <!-- action-docs-outputs -->
 
 <!-- action-docs-runs -->

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,16 @@ inputs:
     description: >-
       Set this to "true" to only run pre-commit against changed files, and not
       the entire repository
+  s3-bucket-name:
+    required: false
+    description: S3 bucket name to cache node_modules to speed up dependency installation.
+  s3-bucket-region:
+    required: false
+    description: S3 bucket region to cache node_modules to speed up dependency installation.
+outputs:
+  cache-hit:
+    description: Whether the cache was hit when installing dependencies
+    value: ${{ steps.read_cache.outputs.cache-hit }}
 
 runs:
   using: composite
@@ -72,17 +82,43 @@ runs:
           PRE_COMMIT_ARGS="--files ${{ steps.changed-files.outputs.all_changed_files }}"
           echo "PRE_COMMIT_ARGS=$PRE_COMMIT_ARGS" >> "$GITHUB_ENV"
         fi
+
+    - name: Compute pre-commit cache key
+      if: inputs.s3-bucket-name != ''
+      id: pre_commit_cache_key
+      run: |
+        echo "key=${{ hashFiles('**/.pre-commit-config.yaml') }}" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Load cached pre-commit hooks if available
+      if: inputs.s3-bucket-name != ''
+      uses: everpcpc/actions-cache@v2
+      id: read_cache
+      with:
+        bucket: ${{ inputs.s3-bucket-name }}
+        use-fallback: false
+        path: ${{ runner.temp }}/${{ env.cache-name }}-${{ steps.pre_commit_cache_key.outputs.key }}
+        key: ${{ env.cache-name }}-${{ steps.pre_commit_cache_key.outputs.key }}
+        restore-keys: ${{ env.cache-name }}-
+      env:
+        AWS_REGION: ${{ inputs.s3-bucket-region }}
+        cache-name: ${{ github.event.repository.name }}/cache-pre-commit
+
     - name: Pre-commit (action)
       # Same as above, this will install and run pre-commit for us
       if: env.PRE_COMMIT_BIN == null && steps.pre-commit-config.outputs.exists != 'false'
       uses: pre-commit/action@v3.0.1
       with:
         extra_args: ${{ env.PRE_COMMIT_ARGS }}
+      env:
+        PRE_COMMIT_HOME: ${{ runner.temp }}/${{ github.event.repository.name }}/cache-pre-commit-${{ steps.pre_commit_cache_key.outputs.key }}
     - name: Pre-commit (from PATH)
       # Run pre-commit directly if we found it on the PATH
       if: env.PRE_COMMIT_BIN != null && steps.pre-commit-config.outputs.exists != 'false'
       shell: bash
       run: pre-commit run --show-diff-on-failure --color=always ${{ env.PRE_COMMIT_ARGS }}
+      env:
+        PRE_COMMIT_HOME: ${{ runner.temp }}/${{ github.event.repository.name }}/cache-pre-commit-${{ steps.pre_commit_cache_key.outputs.key }}
+
     - name: Restore commitlint config
       if: always() && hashFiles(inputs.config-file) != '' && inputs.turo-conventional-commit == 'true'
       shell: bash


### PR DESCRIPTION

**Description**

This PR updates this action so that we can cache pre-commit hooks in S3 when the right inputs are passed.

Doing this requires using a different folder for the pre-commit cache to not pollute other runs (in the case of shared runners).

**Changes**

* feat: add support to cache pre-commit in s3

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
