### PR TITLE
feat: apply pre-commit migrate-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: v3.1.0
     hooks:
       - id: prettier
-        stages: [commit]
+        stages: [pre-commit]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.22.0
     hooks:


### PR DESCRIPTION
Just `pre-commit migrate-config` to release node 22 update (https://github.com/open-turo/action-pre-commit/commit/c426cd5cb1afc59148d89be74b557b43314caf05)
