### PR TITLE
feat(lint): exclude gradlew from linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: dist/.*
+exclude: ^(dist/.*|gradlew)$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0 # Use the ref you want to point at


### PR DESCRIPTION
**Description**

This change prevents modifying the gradlew shell script, which could potentially break its functionality.



**Changes**

* feat(lint): exclude gradlew from linting

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
