### PR TITLE
feat: add disable-commitlint input to skip commitlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ jobs:
 | parameter | description | required | default |
 | --- | --- | --- | --- |
 | config-file | The config file to present to commitlint-github-action | `true` | .commitlintrc.yaml |
+| disable-commitlint | Set this to "true" to disable commitlint entirely | `false` | false |
 | turo-conventional-commit | Set this to "false" to customize conventional commit configuration | `true` | true |
 | only-changed | Set this to "true" to only run pre-commit against changed files, and not the entire repository | `false` |  |
 | stage | Set this to run pre-commit against a specific stage of the pre-commit hooks. | `false` |  |

--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,10 @@ inputs:
     required: true
     description: The config file to present to commitlint-github-action
     default: .commitlintrc.yaml
+  disable-commitlint:
+    required: false
+    description: Set this to "true" to disable commitlint entirely
+    default: "false"
   turo-conventional-commit:
     required: true
     description: Set this to "false" to customize conventional commit configuration
@@ -89,6 +93,7 @@ runs:
         node-version: ${{ steps.node-version.outputs.version }}
     - name: Commitlint
       # This version needs to be sync'd with the repo HEAD if a major version is cut
+      if: inputs.disable-commitlint != 'true'
       uses: open-turo/action-pre-commit/commitlint@v3
       with:
         restore-config: "false"
@@ -152,7 +157,7 @@ runs:
         PRE_COMMIT_HOME: ${{ runner.temp }}/${{ github.event.repository.name }}/cache-pre-commit-${{ steps.pre_commit_cache_key.outputs.key }}
 
     - name: Restore commitlint config
-      if: always() && hashFiles(inputs.config-file) != '' && inputs.turo-conventional-commit == 'true'
+      if: always() && inputs.disable-commitlint != 'true' && hashFiles(inputs.config-file) != '' && inputs.turo-conventional-commit == 'true'
       shell: bash
       env:
         CONFIG_FILE: ${{ inputs.config-file }}


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
feat: add disable-commitlint input to skip commitlint
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
Adds a new optional `disable-commitlint` input (default `"false"`) that
allows repos that don't enforce conventional commits to still use
action-pre-commit without running commitlint.
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* feat: add disable-commitlint input to skip commitlint (+7/-1)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)