### PR TITLE
[DEVEX-852] Fix action-pre-commit to use runner image's pre-loaded hook cache

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -128,8 +128,16 @@ runs:
     - name: Compute pre-commit cache key
       if: inputs.s3-bucket-name != ''
       id: pre_commit_cache_key
+      env:
+        RUNNER_TEMP: ${{ runner.temp }}
+        REPO_NAME: ${{ github.event.repository.name }}
       run: |
-        echo "key=${{ hashFiles('**/.pre-commit-config.yaml') }}" >> $GITHUB_OUTPUT
+        KEY="${{ hashFiles('**/.pre-commit-config.yaml') }}"
+        echo "key=$KEY" >> "$GITHUB_OUTPUT"
+        # Point pre-commit at the S3-backed cache dir. When this step is skipped
+        # (no S3 bucket), PRE_COMMIT_HOME stays unset and pre-commit uses its
+        # default (~/.cache/pre-commit), e.g. the runner image's pre-loaded cache.
+        echo "PRE_COMMIT_HOME=$RUNNER_TEMP/$REPO_NAME/cache-pre-commit-$KEY" >> "$GITHUB_ENV"
       shell: bash
     - name: Load cached pre-commit hooks if available
       if: inputs.s3-bucket-name != ''
@@ -152,9 +160,10 @@ runs:
       shell: bash
     - name: Pre-commit (from PATH)
       shell: bash
-      run: pre-commit run --show-diff-on-failure --color=always ${{ env.PRE_COMMIT_ARGS }}
-      env:
-        PRE_COMMIT_HOME: ${{ runner.temp }}/${{ github.event.repository.name }}/cache-pre-commit-${{ steps.pre_commit_cache_key.outputs.key }}
+      # PRE_COMMIT_HOME (set only when an S3 cache is configured) and
+      # PRE_COMMIT_ARGS are inherited from $GITHUB_ENV set in earlier steps.
+      # PRE_COMMIT_ARGS is intentionally unquoted to preserve multi-argument behavior.
+      run: pre-commit run --show-diff-on-failure --color=always $PRE_COMMIT_ARGS
 
     - name: Restore commitlint config
       if: always() && inputs.disable-commitlint != 'true' && hashFiles(inputs.config-file) != '' && inputs.turo-conventional-commit == 'true'


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
DEVEX-852: Fix action-pre-commit to use runner image's pre-loaded hook cache
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
h3. Problem

{{open-turo/action-pre-commit@v3}} unconditionally sets {{PRE_COMMIT_HOME}} to an empty temp directory, bypassing the pre-loaded cache at {{~/.cache/pre-commit}} that the runner image ({{turo/dkr-actions-runner}}) already provides.

Every CI run rebuilds all hook environments from scratch. On 500mcpu runners, compiling actionlint's Go binary alone takes 1-4 minutes. Confirmed in logs across multiple repos — all show:

{noformat}PRE_COMMIT_HOME: /home/runner/_work/_temp/{repo}/cache-pre-commit-
[INFO] Installing environment for ... This may take a few minutes...{noformat}

h3. Root Cause

In {{action.yaml}}, the "Pre-commit (from PATH)" step always sets:

{code:yaml}env:
  PRE_COMMIT_HOME: ${{ runner.temp }}/${{ github.event.repository.name }}/cache-pre-commit-${{ steps.pre_commit_cache_key.outputs.key }}{code}

When {{s3-bucket-name}} is not provided (98% of repos), the cache key is empty and {{PRE_COMMIT_HOME}} points to a non-existent temp path. The runner image's 179 pre-installed hook environments are ignored.

h3. Proposed Change

Make {{PRE_COMMIT_HOME}} conditional — only set it when the S3 cache is configured. Otherwise, let pre-commit use the default {{~/.cache/pre-commit}}. One-file change in {{open-turo/action-pre-commit/action.yaml}}, minor version bump on v3.

h3. Impact

* 204 repos benefit automatically — no per-repo changes needed
* Estimated ~150-180 CI hours/month saved
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
Fixes [DEVEX-852](https://team-turo.atlassian.net/browse/DEVEX-852)
<!-- fotingo:end fixed-issues -->

**Changes**

<!-- fotingo:start changes -->
* fix: only override PRE_COMMIT_HOME when S3 cache is configured (+6/-1)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
